### PR TITLE
NXP-23348: Fix orderBy test for MongoDB based on DocumentModelComparator

### DIFF
--- a/src/main/java/org/nuxeo/audit/storage/impl/DirectoryAuditStorage.java
+++ b/src/main/java/org/nuxeo/audit/storage/impl/DirectoryAuditStorage.java
@@ -140,7 +140,7 @@ public class DirectoryAuditStorage implements AuditStorage {
 
         // Get the orderBy map from the query builder.
         Map<String, String> orderBy = queryBuilder.orders().stream().collect(
-                Collectors.toMap(o -> o.reference.name, o -> o.isDescending ? "DESC" : "ASC"));
+                Collectors.toMap(o -> o.reference.name, o -> o.isDescending ? "desc" : "asc"));
 
         // Get the limit and offset from the query builder.
         int limit = (int) queryBuilder.limit();

--- a/src/main/java/org/nuxeo/audit/storage/impl/DirectoryAuditStorage.java
+++ b/src/main/java/org/nuxeo/audit/storage/impl/DirectoryAuditStorage.java
@@ -58,7 +58,7 @@ import org.nuxeo.runtime.api.Framework;
 /**
  * Audit storage implementation for an Audit directory.
  * 
- * @since 9.3
+ * @since 9.10
  */
 public class DirectoryAuditStorage implements AuditStorage {
 

--- a/src/test/java/org/nuxeo/audit/storage/impl/TestDirectoryAuditStorage.java
+++ b/src/test/java/org/nuxeo/audit/storage/impl/TestDirectoryAuditStorage.java
@@ -134,13 +134,13 @@ public class TestDirectoryAuditStorage {
         List<LogEntry> logEntries = storage.queryLogs(queryBuilder);
         assertEquals(2, storage.queryLogs(queryBuilder).size());
 
-        // Query builder with an orderBy ASC.
+        // Query builder with an orderBy DESC.
         queryBuilder.order(new OrderByExpr(new Reference(DirectoryAuditStorage.ID_COLUMN), true));
         logEntries = storage.queryLogs(queryBuilder);
         assertEquals(2, logEntries.size());
         assertEquals("/My doc 2", logEntries.get(0).getDocPath());
 
-        // Query builder with an orderBy DESC.
+        // Query builder with an orderBy ASC.
         queryBuilder = new AuditQueryBuilder();
         queryBuilder.order(new OrderByExpr(new Reference(DirectoryAuditStorage.ID_COLUMN), false));
         logEntries = storage.queryLogs(queryBuilder);

--- a/src/test/java/org/nuxeo/audit/storage/impl/TestDirectoryAuditStorage.java
+++ b/src/test/java/org/nuxeo/audit/storage/impl/TestDirectoryAuditStorage.java
@@ -60,7 +60,7 @@ import org.nuxeo.runtime.test.runner.Features;
 import org.nuxeo.runtime.test.runner.FeaturesRunner;
 
 /**
- * @since 9.3
+ * @since 9.10
  */
 @RunWith(FeaturesRunner.class)
 @Features({ AuditFeature.class })


### PR DESCRIPTION
Trying to fix the following failing test for MongoDB configuration:
https://qa.nuxeo.org/jenkins/job/master/job/nuxeo-master-fullbuild-part1-multidb/Slave=MULTIDB_LINUX,dbprofile=mongodb,jdk=java-8-oracle/596/testReport/junit/org.nuxeo.audit.storage.impl/TestDirectoryAuditStorage/testQueryLogs/

I think it is failing because of the order case (`asc` / `ASC`):
Indeed, `DirectoryAuditStorage.queryLogs` calls `session.query`.
But unlike `SQLSession`, `MongoDBSession.query` calls `AbstractDirectory.orderEntries`,
which creates a new `DocumentModelComparator`,
whose `compare` method uses `boolean asc = ORDER_ASC.equals(e.getValue())` (checking the case)
where `ORDER_ASC` is "asc" in lower case.
